### PR TITLE
switch to depending on `lucet-runtime-internals`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ categories = ["wasm"]
 edition = "2018"
 
 [dependencies]
-lucet-runtime = "0.1.1"
+lucet-runtime-internals = "0.2.1"
 wasi-common = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,13 @@
 #![allow(clippy::too_many_arguments)]
 
-pub use lucet_runtime::{self, vmctx::lucet_vmctx};
+pub use lucet_runtime_internals::{lucet_hostcall_terminate, lucet_hostcalls, vmctx::lucet_vmctx};
 pub use wasi_common::*;
 
-use lucet_runtime::lucet_hostcall_terminate;
 use std::mem;
 use std::rc::Rc;
 use wasi_common::hostcalls::*;
 
-lucet_runtime::lucet_hostcalls! {
+lucet_hostcalls! {
 
 #[no_mangle]
 pub unsafe extern "C" fn __wasi_proc_exit(


### PR DESCRIPTION
This makes linking happier downstream; `lucet-runtime` should only appear once in the transitive dependency tree of any executable.