### PR TITLE
update wasi-common to 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ edition = "2018"
 
 [dependencies]
 lucet-runtime-internals = "0.4"
-wasi-common = "0.2"
+wasi-common = "0.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ lucet_hostcalls! {
 #[no_mangle]
 pub unsafe extern "C" fn __wasi_proc_exit(
     &mut _lucet_vmctx,
-    rval: wasm32::__wasi_exitcode_t,
+    rval: wasi::__wasi_exitcode_t,
 ) -> ! {
     export_wasi_funcs();
     lucet_hostcall_terminate!(rval);
@@ -22,9 +22,9 @@ pub unsafe extern "C" fn __wasi_proc_exit(
 #[no_mangle]
 pub unsafe extern "C" fn __wasi_args_get(
     &mut lucet_ctx,
-    argv_ptr: wasm32::uintptr_t,
-    argv_buf: wasm32::uintptr_t,
-) -> wasm32::__wasi_errno_t {
+    argv_ptr: wasi32::uintptr_t,
+    argv_buf: wasi32::uintptr_t,
+) -> wasi::__wasi_errno_t {
     let wasi_ctx = &lucet_ctx.get_embed_ctx::<WasiCtx>();
     let heap = &mut lucet_ctx.heap_mut();
     args_get(wasi_ctx, heap, argv_ptr, argv_buf)
@@ -33,25 +33,25 @@ pub unsafe extern "C" fn __wasi_args_get(
 #[no_mangle]
 pub unsafe extern "C" fn __wasi_args_sizes_get(
     &mut lucet_ctx,
-    argc_ptr: wasm32::uintptr_t,
-    argv_buf_size_ptr: wasm32::uintptr_t,
-) -> wasm32::__wasi_errno_t {
+    argc_ptr: wasi32::uintptr_t,
+    argv_buf_size_ptr: wasi32::uintptr_t,
+) -> wasi::__wasi_errno_t {
     let wasi_ctx = &lucet_ctx.get_embed_ctx::<WasiCtx>();
     let heap = &mut lucet_ctx.heap_mut();
     args_sizes_get(wasi_ctx, heap, argc_ptr, argv_buf_size_ptr)
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn __wasi_sched_yield(&mut _lucet_ctx,) -> wasm32::__wasi_errno_t {
+pub unsafe extern "C" fn __wasi_sched_yield(&mut _lucet_ctx,) -> wasi::__wasi_errno_t {
     sched_yield()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn __wasi_clock_res_get(
     &mut lucet_ctx,
-    clock_id: wasm32::__wasi_clockid_t,
-    resolution_ptr: wasm32::uintptr_t,
-) -> wasm32::__wasi_errno_t {
+    clock_id: wasi::__wasi_clockid_t,
+    resolution_ptr: wasi32::uintptr_t,
+) -> wasi::__wasi_errno_t {
     let heap = &mut lucet_ctx.heap_mut();
     clock_res_get(heap, clock_id, resolution_ptr)
 }
@@ -59,10 +59,10 @@ pub unsafe extern "C" fn __wasi_clock_res_get(
 #[no_mangle]
 pub unsafe extern "C" fn __wasi_clock_time_get(
     &mut lucet_ctx,
-    clock_id: wasm32::__wasi_clockid_t,
-    precision: wasm32::__wasi_timestamp_t,
-    time_ptr: wasm32::uintptr_t,
-) -> wasm32::__wasi_errno_t {
+    clock_id: wasi::__wasi_clockid_t,
+    precision: wasi::__wasi_timestamp_t,
+    time_ptr: wasi32::uintptr_t,
+) -> wasi::__wasi_errno_t {
     let heap = &mut lucet_ctx.heap_mut();
     clock_time_get(heap, clock_id, precision, time_ptr)
 }
@@ -70,9 +70,9 @@ pub unsafe extern "C" fn __wasi_clock_time_get(
 #[no_mangle]
 pub unsafe extern "C" fn __wasi_environ_get(
     &mut lucet_ctx,
-    environ_ptr: wasm32::uintptr_t,
-    environ_buf: wasm32::uintptr_t,
-) -> wasm32::__wasi_errno_t {
+    environ_ptr: wasi32::uintptr_t,
+    environ_buf: wasi32::uintptr_t,
+) -> wasi::__wasi_errno_t {
     let wasi_ctx = &lucet_ctx.get_embed_ctx::<WasiCtx>();
     let heap = &mut lucet_ctx.heap_mut();
     environ_get(wasi_ctx, heap, environ_ptr, environ_buf)
@@ -81,9 +81,9 @@ pub unsafe extern "C" fn __wasi_environ_get(
 #[no_mangle]
 pub unsafe extern "C" fn __wasi_environ_sizes_get(
     &mut lucet_ctx,
-    environ_count_ptr: wasm32::uintptr_t,
-    environ_size_ptr: wasm32::uintptr_t,
-) -> wasm32::__wasi_errno_t {
+    environ_count_ptr: wasi32::uintptr_t,
+    environ_size_ptr: wasi32::uintptr_t,
+) -> wasi::__wasi_errno_t {
     let wasi_ctx = &lucet_ctx.get_embed_ctx::<WasiCtx>();
     let heap = &mut lucet_ctx.heap_mut();
     environ_sizes_get(wasi_ctx, heap, environ_count_ptr, environ_size_ptr)
@@ -92,8 +92,8 @@ pub unsafe extern "C" fn __wasi_environ_sizes_get(
 #[no_mangle]
 pub unsafe extern "C" fn __wasi_fd_close(
     &mut lucet_ctx,
-    fd: wasm32::__wasi_fd_t,
-) -> wasm32::__wasi_errno_t {
+    fd: wasi::__wasi_fd_t,
+) -> wasi::__wasi_errno_t {
     let wasi_ctx = &mut lucet_ctx.get_embed_ctx_mut::<WasiCtx>();
     fd_close(wasi_ctx, fd)
 }
@@ -101,9 +101,9 @@ pub unsafe extern "C" fn __wasi_fd_close(
 #[no_mangle]
 pub unsafe extern "C" fn __wasi_fd_fdstat_get(
     &mut lucet_ctx,
-    fd: wasm32::__wasi_fd_t,
-    fdstat_ptr: wasm32::uintptr_t,
-) -> wasm32::__wasi_errno_t {
+    fd: wasi::__wasi_fd_t,
+    fdstat_ptr: wasi32::uintptr_t,
+) -> wasi::__wasi_errno_t {
     let wasi_ctx = &lucet_ctx.get_embed_ctx::<WasiCtx>();
     let heap = &mut lucet_ctx.heap_mut();
     fd_fdstat_get(wasi_ctx, heap, fd, fdstat_ptr)
@@ -112,9 +112,9 @@ pub unsafe extern "C" fn __wasi_fd_fdstat_get(
 #[no_mangle]
 pub unsafe extern "C" fn __wasi_fd_fdstat_set_flags(
     &mut lucet_ctx,
-    fd: wasm32::__wasi_fd_t,
-    fdflags: wasm32::__wasi_fdflags_t,
-) -> wasm32::__wasi_errno_t {
+    fd: wasi::__wasi_fd_t,
+    fdflags: wasi::__wasi_fdflags_t,
+) -> wasi::__wasi_errno_t {
     let wasi_ctx = &lucet_ctx.get_embed_ctx::<WasiCtx>();
     fd_fdstat_set_flags(wasi_ctx, fd, fdflags)
 }
@@ -122,10 +122,10 @@ pub unsafe extern "C" fn __wasi_fd_fdstat_set_flags(
 #[no_mangle]
 pub unsafe extern "C" fn __wasi_fd_tell(
     &mut lucet_ctx,
-    fd: wasm32::__wasi_fd_t,
-    offset: wasm32::uintptr_t,
-) -> wasm32::__wasi_errno_t {
-    let wasi_ctx = &lucet_ctx.get_embed_ctx::<WasiCtx>();
+    fd: wasi::__wasi_fd_t,
+    offset: wasi32::uintptr_t,
+) -> wasi::__wasi_errno_t {
+    let wasi_ctx = &mut lucet_ctx.get_embed_ctx_mut::<WasiCtx>();
     let heap = &mut lucet_ctx.heap_mut();
     fd_tell(wasi_ctx, heap, fd, offset)
 }
@@ -133,12 +133,12 @@ pub unsafe extern "C" fn __wasi_fd_tell(
 #[no_mangle]
 pub unsafe extern "C" fn __wasi_fd_seek(
     &mut lucet_ctx,
-    fd: wasm32::__wasi_fd_t,
-    offset: wasm32::__wasi_filedelta_t,
-    whence: wasm32::__wasi_whence_t,
-    newoffset: wasm32::uintptr_t,
-) -> wasm32::__wasi_errno_t {
-    let wasi_ctx = &lucet_ctx.get_embed_ctx::<WasiCtx>();
+    fd: wasi::__wasi_fd_t,
+    offset: wasi::__wasi_filedelta_t,
+    whence: wasi::__wasi_whence_t,
+    newoffset: wasi32::uintptr_t,
+) -> wasi::__wasi_errno_t {
+    let wasi_ctx = &mut lucet_ctx.get_embed_ctx_mut::<WasiCtx>();
     let heap = &mut lucet_ctx.heap_mut();
     fd_seek(wasi_ctx, heap, fd, offset, whence, newoffset)
 }
@@ -146,9 +146,9 @@ pub unsafe extern "C" fn __wasi_fd_seek(
 #[no_mangle]
 pub unsafe extern "C" fn __wasi_fd_prestat_get(
     &mut lucet_ctx,
-    fd: wasm32::__wasi_fd_t,
-    prestat_ptr: wasm32::uintptr_t,
-) -> wasm32::__wasi_errno_t {
+    fd: wasi::__wasi_fd_t,
+    prestat_ptr: wasi32::uintptr_t,
+) -> wasi::__wasi_errno_t {
     let wasi_ctx = &lucet_ctx.get_embed_ctx::<WasiCtx>();
     let heap = &mut lucet_ctx.heap_mut();
     fd_prestat_get(wasi_ctx, heap, fd, prestat_ptr)
@@ -157,10 +157,10 @@ pub unsafe extern "C" fn __wasi_fd_prestat_get(
 #[no_mangle]
 pub unsafe extern "C" fn __wasi_fd_prestat_dir_name(
     &mut lucet_ctx,
-    fd: wasm32::__wasi_fd_t,
-    path_ptr: wasm32::uintptr_t,
-    path_len: wasm32::size_t,
-) -> wasm32::__wasi_errno_t {
+    fd: wasi::__wasi_fd_t,
+    path_ptr: wasi32::uintptr_t,
+    path_len: wasi32::size_t,
+) -> wasi::__wasi_errno_t {
     let wasi_ctx = &lucet_ctx.get_embed_ctx::<WasiCtx>();
     let heap = &mut lucet_ctx.heap_mut();
     fd_prestat_dir_name(wasi_ctx, heap, fd, path_ptr, path_len)
@@ -169,11 +169,11 @@ pub unsafe extern "C" fn __wasi_fd_prestat_dir_name(
 #[no_mangle]
 pub unsafe extern "C" fn __wasi_fd_read(
     &mut lucet_ctx,
-    fd: wasm32::__wasi_fd_t,
-    iovs_ptr: wasm32::uintptr_t,
-    iovs_len: wasm32::size_t,
-    nread: wasm32::uintptr_t,
-) -> wasm32::__wasi_errno_t {
+    fd: wasi::__wasi_fd_t,
+    iovs_ptr: wasi32::uintptr_t,
+    iovs_len: wasi32::size_t,
+    nread: wasi32::uintptr_t,
+) -> wasi::__wasi_errno_t {
     let wasi_ctx = &mut lucet_ctx.get_embed_ctx_mut::<WasiCtx>();
     let heap = &mut lucet_ctx.heap_mut();
     fd_read(wasi_ctx, heap, fd, iovs_ptr, iovs_len, nread)
@@ -182,11 +182,11 @@ pub unsafe extern "C" fn __wasi_fd_read(
 #[no_mangle]
 pub unsafe extern "C" fn __wasi_fd_write(
     &mut lucet_ctx,
-    fd: wasm32::__wasi_fd_t,
-    iovs_ptr: wasm32::uintptr_t,
-    iovs_len: wasm32::size_t,
-    nwritten: wasm32::uintptr_t,
-) -> wasm32::__wasi_errno_t {
+    fd: wasi::__wasi_fd_t,
+    iovs_ptr: wasi32::uintptr_t,
+    iovs_len: wasi32::size_t,
+    nwritten: wasi32::uintptr_t,
+) -> wasi::__wasi_errno_t {
     let wasi_ctx = &mut lucet_ctx.get_embed_ctx_mut::<WasiCtx>();
     let heap = &mut lucet_ctx.heap_mut();
     fd_write(wasi_ctx, heap, fd, iovs_ptr, iovs_len, nwritten)
@@ -195,16 +195,16 @@ pub unsafe extern "C" fn __wasi_fd_write(
 #[no_mangle]
 pub unsafe extern "C" fn __wasi_path_open(
     &mut lucet_ctx,
-    dirfd: wasm32::__wasi_fd_t,
-    dirflags: wasm32::__wasi_lookupflags_t,
-    path_ptr: wasm32::uintptr_t,
-    path_len: wasm32::size_t,
-    oflags: wasm32::__wasi_oflags_t,
-    fs_rights_base: wasm32::__wasi_rights_t,
-    fs_rights_inheriting: wasm32::__wasi_rights_t,
-    fs_flags: wasm32::__wasi_fdflags_t,
-    fd_out_ptr: wasm32::uintptr_t,
-) -> wasm32::__wasi_errno_t {
+    dirfd: wasi::__wasi_fd_t,
+    dirflags: wasi::__wasi_lookupflags_t,
+    path_ptr: wasi32::uintptr_t,
+    path_len: wasi32::size_t,
+    oflags: wasi::__wasi_oflags_t,
+    fs_rights_base: wasi::__wasi_rights_t,
+    fs_rights_inheriting: wasi::__wasi_rights_t,
+    fs_flags: wasi::__wasi_fdflags_t,
+    fd_out_ptr: wasi32::uintptr_t,
+) -> wasi::__wasi_errno_t {
     let wasi_ctx = &mut lucet_ctx.get_embed_ctx_mut::<WasiCtx>();
     let heap = &mut lucet_ctx.heap_mut();
     path_open(
@@ -225,9 +225,9 @@ pub unsafe extern "C" fn __wasi_path_open(
 #[no_mangle]
 pub unsafe extern "C" fn __wasi_random_get(
     &mut lucet_ctx,
-    buf_ptr: wasm32::uintptr_t,
-    buf_len: wasm32::size_t,
-) -> wasm32::__wasi_errno_t {
+    buf_ptr: wasi32::uintptr_t,
+    buf_len: wasi32::size_t,
+) -> wasi::__wasi_errno_t {
     let heap = &mut lucet_ctx.heap_mut();
     random_get(heap, buf_ptr, buf_len)
 }
@@ -235,21 +235,22 @@ pub unsafe extern "C" fn __wasi_random_get(
 #[no_mangle]
 pub unsafe extern "C" fn __wasi_poll_oneoff(
     &mut lucet_ctx,
-    input: wasm32::uintptr_t,
-    output: wasm32::uintptr_t,
-    nsubscriptions: wasm32::size_t,
-    nevents: wasm32::uintptr_t,
-) -> wasm32::__wasi_errno_t {
+    input: wasi32::uintptr_t,
+    output: wasi32::uintptr_t,
+    nsubscriptions: wasi32::size_t,
+    nevents: wasi32::uintptr_t,
+) -> wasi::__wasi_errno_t {
+    let wasi_ctx = &lucet_ctx.get_embed_ctx::<WasiCtx>();
     let heap = &mut lucet_ctx.heap_mut();
-    poll_oneoff(heap, input, output, nsubscriptions, nevents)
+    poll_oneoff(wasi_ctx, heap, input, output, nsubscriptions, nevents)
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn __wasi_fd_filestat_get(
     &mut lucet_ctx,
-    fd: wasm32::__wasi_fd_t,
-    filestat_ptr: wasm32::uintptr_t,
-) -> wasm32::__wasi_errno_t {
+    fd: wasi::__wasi_fd_t,
+    filestat_ptr: wasi32::uintptr_t,
+) -> wasi::__wasi_errno_t {
     let wasi_ctx = &lucet_ctx.get_embed_ctx::<WasiCtx>();
     let heap = &mut lucet_ctx.heap_mut();
     fd_filestat_get(wasi_ctx, heap, fd, filestat_ptr)
@@ -258,12 +259,12 @@ pub unsafe extern "C" fn __wasi_fd_filestat_get(
 #[no_mangle]
 pub unsafe extern "C" fn __wasi_path_filestat_get(
     &mut lucet_ctx,
-    dirfd: wasm32::__wasi_fd_t,
-    dirflags: wasm32::__wasi_lookupflags_t,
-    path_ptr: wasm32::uintptr_t,
-    path_len: wasm32::size_t,
-    filestat_ptr: wasm32::uintptr_t,
-) -> wasm32::__wasi_errno_t {
+    dirfd: wasi::__wasi_fd_t,
+    dirflags: wasi::__wasi_lookupflags_t,
+    path_ptr: wasi32::uintptr_t,
+    path_len: wasi32::size_t,
+    filestat_ptr: wasi32::uintptr_t,
+) -> wasi::__wasi_errno_t {
     let wasi_ctx = &lucet_ctx.get_embed_ctx::<WasiCtx>();
     let heap = &mut lucet_ctx.heap_mut();
     path_filestat_get(
@@ -280,10 +281,10 @@ pub unsafe extern "C" fn __wasi_path_filestat_get(
 #[no_mangle]
 pub unsafe extern "C" fn __wasi_path_create_directory(
     &mut lucet_ctx,
-    dirfd: wasm32::__wasi_fd_t,
-    path_ptr: wasm32::uintptr_t,
-    path_len: wasm32::size_t,
-) -> wasm32::__wasi_errno_t {
+    dirfd: wasi::__wasi_fd_t,
+    path_ptr: wasi32::uintptr_t,
+    path_len: wasi32::size_t,
+) -> wasi::__wasi_errno_t {
     let wasi_ctx = &lucet_ctx.get_embed_ctx::<WasiCtx>();
     let heap = &mut lucet_ctx.heap_mut();
     path_create_directory(wasi_ctx, heap, dirfd, path_ptr, path_len)
@@ -292,10 +293,10 @@ pub unsafe extern "C" fn __wasi_path_create_directory(
 #[no_mangle]
 pub unsafe extern "C" fn __wasi_path_unlink_file(
     &mut lucet_ctx,
-    dirfd: wasm32::__wasi_fd_t,
-    path_ptr: wasm32::uintptr_t,
-    path_len: wasm32::size_t,
-) -> wasm32::__wasi_errno_t {
+    dirfd: wasi::__wasi_fd_t,
+    path_ptr: wasi32::uintptr_t,
+    path_len: wasi32::size_t,
+) -> wasi::__wasi_errno_t {
     let wasi_ctx = &lucet_ctx.get_embed_ctx::<WasiCtx>();
     let heap = &mut lucet_ctx.heap_mut();
     path_unlink_file(wasi_ctx, heap, dirfd, path_ptr, path_len)
@@ -304,10 +305,10 @@ pub unsafe extern "C" fn __wasi_path_unlink_file(
 #[no_mangle]
 pub unsafe extern "C" fn __wasi_fd_allocate(
     &mut lucet_ctx,
-    fd: wasm32::__wasi_fd_t,
-    offset: wasm32::__wasi_filesize_t,
-    len: wasm32::__wasi_filesize_t,
-) -> wasm32::__wasi_errno_t {
+    fd: wasi::__wasi_fd_t,
+    offset: wasi::__wasi_filesize_t,
+    len: wasi::__wasi_filesize_t,
+) -> wasi::__wasi_errno_t {
     let wasi_ctx = &lucet_ctx.get_embed_ctx::<WasiCtx>();
     fd_allocate(wasi_ctx, fd, offset, len)
 }
@@ -315,11 +316,11 @@ pub unsafe extern "C" fn __wasi_fd_allocate(
 #[no_mangle]
 pub unsafe extern "C" fn __wasi_fd_advise(
     &mut lucet_ctx,
-    fd: wasm32::__wasi_fd_t,
-    offset: wasm32::__wasi_filesize_t,
-    len: wasm32::__wasi_filesize_t,
-    advice: wasm32::__wasi_advice_t,
-) -> wasm32::__wasi_errno_t {
+    fd: wasi::__wasi_fd_t,
+    offset: wasi::__wasi_filesize_t,
+    len: wasi::__wasi_filesize_t,
+    advice: wasi::__wasi_advice_t,
+) -> wasi::__wasi_errno_t {
     let wasi_ctx = &lucet_ctx.get_embed_ctx::<WasiCtx>();
     fd_advise(wasi_ctx, fd, offset, len, advice)
 }
@@ -327,8 +328,8 @@ pub unsafe extern "C" fn __wasi_fd_advise(
 #[no_mangle]
 pub unsafe extern "C" fn __wasi_fd_datasync(
     &mut lucet_ctx,
-    fd: wasm32::__wasi_fd_t,
-) -> wasm32::__wasi_errno_t {
+    fd: wasi::__wasi_fd_t,
+) -> wasi::__wasi_errno_t {
     let wasi_ctx = &lucet_ctx.get_embed_ctx::<WasiCtx>();
     fd_datasync(wasi_ctx, fd)
 }
@@ -336,8 +337,8 @@ pub unsafe extern "C" fn __wasi_fd_datasync(
 #[no_mangle]
 pub unsafe extern "C" fn __wasi_fd_sync(
     &mut lucet_ctx,
-    fd: wasm32::__wasi_fd_t,
-) -> wasm32::__wasi_errno_t {
+    fd: wasi::__wasi_fd_t,
+) -> wasi::__wasi_errno_t {
     let wasi_ctx = &lucet_ctx.get_embed_ctx::<WasiCtx>();
     fd_sync(wasi_ctx, fd)
 }
@@ -345,10 +346,10 @@ pub unsafe extern "C" fn __wasi_fd_sync(
 #[no_mangle]
 pub unsafe extern "C" fn __wasi_fd_fdstat_set_rights(
     &mut lucet_ctx,
-    fd: wasm32::__wasi_fd_t,
-    fs_rights_base: wasm32::__wasi_rights_t,
-    fs_rights_inheriting: wasm32::__wasi_rights_t,
-) -> wasm32::__wasi_errno_t {
+    fd: wasi::__wasi_fd_t,
+    fs_rights_base: wasi::__wasi_rights_t,
+    fs_rights_inheriting: wasi::__wasi_rights_t,
+) -> wasi::__wasi_errno_t {
     let wasi_ctx = &mut lucet_ctx.get_embed_ctx_mut::<WasiCtx>();
     fd_fdstat_set_rights(wasi_ctx, fd, fs_rights_base, fs_rights_inheriting)
 }
@@ -356,9 +357,9 @@ pub unsafe extern "C" fn __wasi_fd_fdstat_set_rights(
 #[no_mangle]
 pub unsafe extern "C" fn __wasi_fd_filestat_set_size(
     &mut lucet_ctx,
-    fd: wasm32::__wasi_fd_t,
-    st_size: wasm32::__wasi_filesize_t,
-) -> wasm32::__wasi_errno_t {
+    fd: wasi::__wasi_fd_t,
+    st_size: wasi::__wasi_filesize_t,
+) -> wasi::__wasi_errno_t {
     let wasi_ctx = &lucet_ctx.get_embed_ctx::<WasiCtx>();
     fd_filestat_set_size(wasi_ctx, fd, st_size)
 }
@@ -366,11 +367,11 @@ pub unsafe extern "C" fn __wasi_fd_filestat_set_size(
 #[no_mangle]
 pub unsafe extern "C" fn __wasi_fd_filestat_set_times(
     &mut lucet_ctx,
-    fd: wasm32::__wasi_fd_t,
-    st_atim: wasm32::__wasi_timestamp_t,
-    st_mtim: wasm32::__wasi_timestamp_t,
-    fst_flags: wasm32::__wasi_fstflags_t,
-) -> wasm32::__wasi_errno_t {
+    fd: wasi::__wasi_fd_t,
+    st_atim: wasi::__wasi_timestamp_t,
+    st_mtim: wasi::__wasi_timestamp_t,
+    fst_flags: wasi::__wasi_fstflags_t,
+) -> wasi::__wasi_errno_t {
     let wasi_ctx = &lucet_ctx.get_embed_ctx::<WasiCtx>();
     fd_filestat_set_times(wasi_ctx, fd, st_atim, st_mtim, fst_flags)
 }
@@ -378,12 +379,12 @@ pub unsafe extern "C" fn __wasi_fd_filestat_set_times(
 #[no_mangle]
 pub unsafe extern "C" fn __wasi_fd_pread(
     &mut lucet_ctx,
-    fd: wasm32::__wasi_fd_t,
-    iovs_ptr: wasm32::uintptr_t,
-    iovs_len: wasm32::size_t,
-    offset: wasm32::__wasi_filesize_t,
-    nread: wasm32::uintptr_t,
-) -> wasm32::__wasi_errno_t {
+    fd: wasi::__wasi_fd_t,
+    iovs_ptr: wasi32::uintptr_t,
+    iovs_len: wasi32::size_t,
+    offset: wasi::__wasi_filesize_t,
+    nread: wasi32::uintptr_t,
+) -> wasi::__wasi_errno_t {
     let wasi_ctx = &lucet_ctx.get_embed_ctx::<WasiCtx>();
     let heap = &mut lucet_ctx.heap_mut();
     fd_pread(wasi_ctx, heap, fd, iovs_ptr, iovs_len, offset, nread)
@@ -392,12 +393,12 @@ pub unsafe extern "C" fn __wasi_fd_pread(
 #[no_mangle]
 pub unsafe extern "C" fn __wasi_fd_pwrite(
     &mut lucet_ctx,
-    fd: wasm32::__wasi_fd_t,
-    iovs_ptr: wasm32::uintptr_t,
-    iovs_len: wasm32::size_t,
-    offset: wasm32::__wasi_filesize_t,
-    nwritten: wasm32::uintptr_t,
-) -> wasm32::__wasi_errno_t {
+    fd: wasi::__wasi_fd_t,
+    iovs_ptr: wasi32::uintptr_t,
+    iovs_len: wasi32::size_t,
+    offset: wasi::__wasi_filesize_t,
+    nwritten: wasi32::uintptr_t,
+) -> wasi::__wasi_errno_t {
     let wasi_ctx = &lucet_ctx.get_embed_ctx::<WasiCtx>();
     let heap = &mut lucet_ctx.heap_mut();
     fd_pwrite(wasi_ctx, heap, fd, iovs_ptr, iovs_len, offset, nwritten)
@@ -406,13 +407,13 @@ pub unsafe extern "C" fn __wasi_fd_pwrite(
 #[no_mangle]
 pub unsafe extern "C" fn __wasi_fd_readdir(
     &mut lucet_ctx,
-    fd: wasm32::__wasi_fd_t,
-    buf: wasm32::uintptr_t,
-    buf_len: wasm32::size_t,
-    cookie: wasm32::__wasi_dircookie_t,
-    bufused: wasm32::uintptr_t,
-) -> wasm32::__wasi_errno_t {
-    let wasi_ctx = &lucet_ctx.get_embed_ctx::<WasiCtx>();
+    fd: wasi::__wasi_fd_t,
+    buf: wasi32::uintptr_t,
+    buf_len: wasi32::size_t,
+    cookie: wasi::__wasi_dircookie_t,
+    bufused: wasi32::uintptr_t,
+) -> wasi::__wasi_errno_t {
+    let wasi_ctx = &mut lucet_ctx.get_embed_ctx_mut::<WasiCtx>();
     let heap = &mut lucet_ctx.heap_mut();
     fd_readdir(wasi_ctx, heap, fd, buf, buf_len, cookie, bufused)
 }
@@ -420,9 +421,9 @@ pub unsafe extern "C" fn __wasi_fd_readdir(
 #[no_mangle]
 pub unsafe extern "C" fn __wasi_fd_renumber(
     &mut lucet_ctx,
-    from: wasm32::__wasi_fd_t,
-    to: wasm32::__wasi_fd_t,
-) -> wasm32::__wasi_errno_t {
+    from: wasi::__wasi_fd_t,
+    to: wasi::__wasi_fd_t,
+) -> wasi::__wasi_errno_t {
     let wasi_ctx = &mut lucet_ctx.get_embed_ctx_mut::<WasiCtx>();
     fd_renumber(wasi_ctx, from, to)
 }
@@ -430,14 +431,14 @@ pub unsafe extern "C" fn __wasi_fd_renumber(
 #[no_mangle]
 pub unsafe extern "C" fn __wasi_path_filestat_set_times(
     &mut lucet_ctx,
-    dirfd: wasm32::__wasi_fd_t,
-    dirflags: wasm32::__wasi_lookupflags_t,
-    path_ptr: wasm32::uintptr_t,
-    path_len: wasm32::size_t,
-    st_atim: wasm32::__wasi_timestamp_t,
-    st_mtim: wasm32::__wasi_timestamp_t,
-    fst_flags: wasm32::__wasi_fstflags_t,
-) -> wasm32::__wasi_errno_t {
+    dirfd: wasi::__wasi_fd_t,
+    dirflags: wasi::__wasi_lookupflags_t,
+    path_ptr: wasi32::uintptr_t,
+    path_len: wasi32::size_t,
+    st_atim: wasi::__wasi_timestamp_t,
+    st_mtim: wasi::__wasi_timestamp_t,
+    fst_flags: wasi::__wasi_fstflags_t,
+) -> wasi::__wasi_errno_t {
     let wasi_ctx = &lucet_ctx.get_embed_ctx::<WasiCtx>();
     let heap = &mut lucet_ctx.heap_mut();
     path_filestat_set_times(
@@ -448,14 +449,14 @@ pub unsafe extern "C" fn __wasi_path_filestat_set_times(
 #[no_mangle]
 pub unsafe extern "C" fn __wasi_path_link(
     &mut lucet_ctx,
-    old_fd: wasm32::__wasi_fd_t,
-    old_flags: wasm32::__wasi_lookupflags_t,
-    old_path_ptr: wasm32::uintptr_t,
-    old_path_len: wasm32::size_t,
-    new_fd: wasm32::__wasi_fd_t,
-    new_path_ptr: wasm32::uintptr_t,
-    new_path_len: wasm32::size_t,
-) -> wasm32::__wasi_errno_t {
+    old_fd: wasi::__wasi_fd_t,
+    old_flags: wasi::__wasi_lookupflags_t,
+    old_path_ptr: wasi32::uintptr_t,
+    old_path_len: wasi32::size_t,
+    new_fd: wasi::__wasi_fd_t,
+    new_path_ptr: wasi32::uintptr_t,
+    new_path_len: wasi32::size_t,
+) -> wasi::__wasi_errno_t {
     let wasi_ctx = &lucet_ctx.get_embed_ctx::<WasiCtx>();
     let heap = &mut lucet_ctx.heap_mut();
     path_link(
@@ -474,13 +475,13 @@ pub unsafe extern "C" fn __wasi_path_link(
 #[no_mangle]
 pub unsafe extern "C" fn __wasi_path_readlink(
     &mut lucet_ctx,
-    dirfd: wasm32::__wasi_fd_t,
-    path_ptr: wasm32::uintptr_t,
-    path_len: wasm32::size_t,
-    buf_ptr: wasm32::uintptr_t,
-    buf_len: wasm32::size_t,
-    bufused: wasm32::uintptr_t,
-) -> wasm32::__wasi_errno_t {
+    dirfd: wasi::__wasi_fd_t,
+    path_ptr: wasi32::uintptr_t,
+    path_len: wasi32::size_t,
+    buf_ptr: wasi32::uintptr_t,
+    buf_len: wasi32::size_t,
+    bufused: wasi32::uintptr_t,
+) -> wasi::__wasi_errno_t {
     let wasi_ctx = &lucet_ctx.get_embed_ctx::<WasiCtx>();
     let heap = &mut lucet_ctx.heap_mut();
     path_readlink(
@@ -491,10 +492,10 @@ pub unsafe extern "C" fn __wasi_path_readlink(
 #[no_mangle]
 pub unsafe extern "C" fn __wasi_path_remove_directory(
     &mut lucet_ctx,
-    dirfd: wasm32::__wasi_fd_t,
-    path_ptr: wasm32::uintptr_t,
-    path_len: wasm32::size_t,
-) -> wasm32::__wasi_errno_t {
+    dirfd: wasi::__wasi_fd_t,
+    path_ptr: wasi32::uintptr_t,
+    path_len: wasi32::size_t,
+) -> wasi::__wasi_errno_t {
     let wasi_ctx = &lucet_ctx.get_embed_ctx::<WasiCtx>();
     let heap = &mut lucet_ctx.heap_mut();
     path_remove_directory(wasi_ctx, heap, dirfd, path_ptr, path_len)
@@ -503,13 +504,13 @@ pub unsafe extern "C" fn __wasi_path_remove_directory(
 #[no_mangle]
 pub unsafe extern "C" fn __wasi_path_rename(
     &mut lucet_ctx,
-    old_dirfd: wasm32::__wasi_fd_t,
-    old_path_ptr: wasm32::uintptr_t,
-    old_path_len: wasm32::size_t,
-    new_dirfd: wasm32::__wasi_fd_t,
-    new_path_ptr: wasm32::uintptr_t,
-    new_path_len: wasm32::size_t,
-) -> wasm32::__wasi_errno_t {
+    old_dirfd: wasi::__wasi_fd_t,
+    old_path_ptr: wasi32::uintptr_t,
+    old_path_len: wasi32::size_t,
+    new_dirfd: wasi::__wasi_fd_t,
+    new_path_ptr: wasi32::uintptr_t,
+    new_path_len: wasi32::size_t,
+) -> wasi::__wasi_errno_t {
     let wasi_ctx = &lucet_ctx.get_embed_ctx::<WasiCtx>();
     let heap = &mut lucet_ctx.heap_mut();
     path_rename(
@@ -527,12 +528,12 @@ pub unsafe extern "C" fn __wasi_path_rename(
 #[no_mangle]
 pub unsafe extern "C" fn __wasi_path_symlink(
     &mut lucet_ctx,
-    old_path_ptr: wasm32::uintptr_t,
-    old_path_len: wasm32::size_t,
-    dir_fd: wasm32::__wasi_fd_t,
-    new_path_ptr: wasm32::uintptr_t,
-    new_path_len: wasm32::size_t,
-) -> wasm32::__wasi_errno_t {
+    old_path_ptr: wasi32::uintptr_t,
+    old_path_len: wasi32::size_t,
+    dir_fd: wasi::__wasi_fd_t,
+    new_path_ptr: wasi32::uintptr_t,
+    new_path_len: wasi32::size_t,
+) -> wasi::__wasi_errno_t {
     let wasi_ctx = &lucet_ctx.get_embed_ctx::<WasiCtx>();
     let heap = &mut lucet_ctx.heap_mut();
     path_symlink(


### PR DESCRIPTION
Ended up fixing some errors as a byproduct of hacking on wasi-common, figure it'll help to upstream.

This does bring in some bugfixes, but I'm only aware of fixes for *bsd hosts.